### PR TITLE
Fix build with gcc15

### DIFF
--- a/fileops.c
+++ b/fileops.c
@@ -68,7 +68,7 @@ FILE *ftemp(char *templ, const char *mode)
 #else
     int fd = mkstemp(templ);
     if(fd >= 0) {
-        FILE* fdopen();                         /* in case -ansi is used */
+        FILE *fdopen(int fildes, const char *mode); /* in case -ansi is used */
         if(f = fdopen(fd, mode)) return f;
         close(fd);
 #endif


### PR DESCRIPTION
Compile error in gcc15:

```
fileops.c: In function 'ftemp':
fileops.c:71:15: error: conflicting types for 'fdopen'; have 'FILE *(void)'
   71 |         FILE* fdopen();                         /* in case -ansi is used */
      |               ^~~~~~
In file included from fileops.c:2:
/nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/stdio.h:302:14: note: previous declaration of 'fdopen' with type 'FILE *(int,  const char *)'
  302 | extern FILE *fdopen (int __fd, const char *__modes) __THROW
      |              ^~~~~~
fileops.c:72:16: error: too many arguments to function 'fdopen'; expected 0, have 2
   72 |         if(f = fdopen(fd, mode)) return f;
      |                ^~~~~~ ~~
fileops.c:71:15: note: declared here
   71 |         FILE* fdopen();                         /* in case -ansi is used */
      |               ^~~~~~
```

The `fdopen` function should be in `stdio.h` header which is already included in the file. So I just removed the problematic definition.